### PR TITLE
buildRubyGem should inherit the provided ruby

### DIFF
--- a/modules/gems/default.nix
+++ b/modules/gems/default.nix
@@ -29,7 +29,7 @@ rec {
     _: versions:
     pipe versions [
       (map applyDependencies)
-      (map buildRubyGem)
+      (map (spec: buildRubyGem (spec // { inherit ruby; })))
     ]
   );
 


### PR DESCRIPTION
Fixes the issue where ruby is configured with `jemallocSupport` = true, but jemalloc is not propagated into buildRubyGem