### PR TITLE
Use autoPatchelfHook in precompiled gems

### DIFF
--- a/modules/gems/expand.nix
+++ b/modules/gems/expand.nix
@@ -4,6 +4,7 @@
   document,
   gemConfig,
   my,
+  autoPatchelfHook,
   ...
 }:
 
@@ -41,6 +42,8 @@ rec {
         source
         ;
       inherit (source) type compile;
+
+      buildInputs = if source.compile then [ ] else [ autoPatchelfHook ];
 
       dependencies = attrs.dependencies or [ ];
 


### PR DESCRIPTION
Some precompiled gems don't come with a `ruby` platform version. Since `gemConfig` for precompiled gems are ignored, this makes it impossible to customize the build process of them.

This PR adds `autoPatchelfHook` to the `buildInputs` of those gems by default.

Example scenarios:

- `sorbet-static` -> `libexec/sorbet`
- `sass-embedded` -> `ext/sass/dart-sass/src/dart`