### PR TITLE
Ignore $out/bin/*.lock files during buildPhase makeWrapper

### DIFF
--- a/modules/ruby-env/ruby-env.nix
+++ b/modules/ruby-env/ruby-env.nix
@@ -35,6 +35,7 @@ let
         buildPhase = ''
           mkdir -p $out/bin
           for i in ${ruby}/bin/*; do
+            [[ $i == *.lock ]] && continue
             makeWrapper "$i" $out/bin/$(basename "$i") \
               --set GEM_PATH ${rubyEnv}/${ruby.gemPath} \
               --set GEM_HOME ${rubyEnv}/${ruby.gemPath}


### PR DESCRIPTION
Since Ruby 3.3.5, the bin/ dir contains a non-executable *.lock file per executable -- unclear if this is intentional, but it means `makeWrapper` fails the build when those files are encountered.