### PR TITLE
Add ignoreCollisions to ruby-nix.

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -18,6 +18,7 @@
   groups ? null, # null or a list of groups, used by Bundler.setup
   document ? [ ], # e.g. [ "ri" "rdoc" ]
   extraRubySetup ? null, # additional setup script goes here
+  ignoreCollisions ? true, # whether to ignore collisions or abort
 }:
 
 let
@@ -35,6 +36,7 @@ let
         groups
         document
         extraRubySetup
+        ignoreCollisions
         ;
       gemset =
         if builtins.typeOf gemset == "set" then

--- a/modules/ruby-env/ruby-env.nix
+++ b/modules/ruby-env/ruby-env.nix
@@ -8,6 +8,7 @@
   gempaths,
   groups,
   extraRubySetup,
+  ignoreCollisions,
   ...
 }:
 
@@ -23,7 +24,7 @@ let
 
   rubyEnv = buildEnv {
     name = "${name}-ruby-env";
-    ignoreCollisions = true;
+    inherit ignoreCollisions;
     paths = gempaths;
     pathsToLink = [ "/lib" ];
     postBuild = mkBinStubs + lib.optionalString (extraRubySetup != null) extraRubySetup;

--- a/modules/ruby-env/ruby-env.nix
+++ b/modules/ruby-env/ruby-env.nix
@@ -23,6 +23,7 @@ let
 
   rubyEnv = buildEnv {
     name = "${name}-ruby-env";
+    ignoreCollisions = true;
     paths = gempaths;
     pathsToLink = [ "/lib" ];
     postBuild = mkBinStubs + lib.optionalString (extraRubySetup != null) extraRubySetup;


### PR DESCRIPTION
- Allow caller to specify ignoreCollisions.
- If not specified, ignoreCollisions defaults to true.

See this [issue](https://github.com/inscapist/ruby-nix/issues/60) for more details.